### PR TITLE
Fix package consistency quantifier guard

### DIFF
--- a/spec/metabuilder.tla
+++ b/spec/metabuilder.tla
@@ -320,8 +320,9 @@ DataConsistency ==
 
 \* Package consistency: installed packages must be in installed or disabled state
 PackageConsistency ==
-    \A t \in Tenants, p \in installedPackages[t]:
-        packageStates[p] \in {"installed", "disabled", "installing"}
+    \A t \in Tenants:
+        \A p \in installedPackages[t]:
+            packageStates[p] \in {"installed", "disabled", "installing"}
 
 \* DBAL safety: no queries processed in error state
 DBALSafety ==


### PR DESCRIPTION
## Summary
- guard the package consistency invariant by nesting tenant and package quantifiers
- ensure package state validation only iterates over defined installed package sets

## Testing
- bash spec/validate-specs.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f62b9219483318e1158901394f0db)