### PR TITLE
Add large TypeScript audit tooling

### DIFF
--- a/tools/analysis/code/large-typescript-refactor.md
+++ b/tools/analysis/code/large-typescript-refactor.md
@@ -1,0 +1,31 @@
+# Large TypeScript file audit
+
+This helper documents the process for converting oversized TypeScript/TSX files into a modular, lambda-per-file layout.
+
+## Goal
+- Keep each file focused on a single exported lambda/component.
+- Extract helpers, constants, and view fragments into adjacent modules to lower per-file cognitive load.
+- Track remaining oversized files to schedule refactors.
+
+## Usage
+1. From the repository root, run the analyzer:
+   ```bash
+   npx tsx tools/analysis/code/list-large-typescript-files.ts --max-lines 150 --out tools/analysis/code/reports/large-ts-files.json
+   ```
+2. The report records every `.ts`/`.tsx` file above the threshold, their line counts, and a recommendation to break them into smaller modules.
+3. Use the sorted list to prioritize the longest files and migrate logic into dedicated helpers (one primary lambda per file).
+
+## Output format
+The generated JSON includes:
+- `root`: scan starting directory.
+- `maxLines`: line threshold used for the run.
+- `ignored`: directories skipped (tune with `--ignore`).
+- `scanned`: count of `.ts`/`.tsx` files inspected.
+- `overLimit`: number of files exceeding the threshold.
+- `files`: array of file records with paths, line counts, and an extraction recommendation.
+
+## Suggested refactor steps per file
+1. Identify the main exported lambda/component and keep it in place.
+2. Move derived data builders, parsing helpers, or rendering sub-sections into nearby modules (e.g., `./helpers/<name>.ts`).
+3. Re-export shared types from the original file when needed to avoid import churn.
+4. Keep UI-only fragments in `.tsx` leaf components; move business logic into `.ts` utilities when possible.

--- a/tools/analysis/code/list-large-typescript-files.ts
+++ b/tools/analysis/code/list-large-typescript-files.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env tsx
+
+import fs from 'fs/promises'
+import path from 'path'
+
+interface Options {
+  root: string
+  maxLines: number
+  ignore: Set<string>
+  outFile?: string
+}
+
+interface FileReport {
+  path: string
+  lines: number
+  recommendation: string
+}
+
+interface Summary {
+  root: string
+  maxLines: number
+  ignored: string[]
+  scanned: number
+  overLimit: number
+  timestamp: string
+  files: FileReport[]
+}
+
+const DEFAULT_IGNORE = [
+  'node_modules',
+  '.git',
+  '.next',
+  'dist',
+  'build',
+  'coverage',
+  'out',
+  'tmp',
+  '.turbo'
+]
+
+const usage = `Usage: tsx list-large-typescript-files.ts [--root <path>] [--max-lines <number>] [--out <path>] [--ignore <dirA,dirB>]
+
+Scans the repository for .ts/.tsx files longer than the threshold and suggests splitting them into a modular, lambda-per-file structure.`
+
+const parseArgs = (): Options => {
+  const args = process.argv.slice(2)
+  const options: Options = {
+    root: process.cwd(),
+    maxLines: 150,
+    ignore: new Set(DEFAULT_IGNORE),
+  }
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]
+    switch (arg) {
+      case '--root':
+        options.root = path.resolve(args[i + 1] ?? '.')
+        i += 1
+        break
+      case '--max-lines':
+        options.maxLines = Number(args[i + 1] ?? options.maxLines)
+        i += 1
+        break
+      case '--out':
+        options.outFile = args[i + 1]
+        i += 1
+        break
+      case '--ignore': {
+        const extra = (args[i + 1] ?? '')
+          .split(',')
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+        extra.forEach((entry) => options.ignore.add(entry))
+        i += 1
+        break
+      }
+      case '--help':
+        console.log(usage)
+        process.exit(0)
+      default:
+        if (arg.startsWith('--')) {
+          console.warn(`Unknown option: ${arg}`)
+        }
+    }
+  }
+
+  return options
+}
+
+const countLines = async (filePath: string): Promise<number> => {
+  const content = await fs.readFile(filePath, 'utf8')
+  return content.split(/\r?\n/).length
+}
+
+const shouldSkip = (segment: string, ignore: Set<string>): boolean => ignore.has(segment)
+
+const walkFiles = async (options: Options): Promise<{ reports: FileReport[]; total: number }> => {
+  const queue: string[] = [options.root]
+  const reports: FileReport[] = []
+  let total = 0
+
+  while (queue.length > 0) {
+    const current = queue.pop() as string
+    const entries = await fs.readdir(current, { withFileTypes: true })
+    for (const entry of entries) {
+      if (shouldSkip(entry.name, options.ignore)) continue
+      const fullPath = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        queue.push(fullPath)
+        continue
+      }
+      if (!entry.name.endsWith('.ts') && !entry.name.endsWith('.tsx')) continue
+      total += 1
+      const lines = await countLines(fullPath)
+      if (lines > options.maxLines) {
+        const relativePath = path.relative(options.root, fullPath)
+        reports.push({
+          path: relativePath,
+          lines,
+          recommendation: 'Split into focused modules; keep one primary lambda per file and extract helpers.',
+        })
+      }
+    }
+  }
+
+  return { reports: reports.sort((a, b) => b.lines - a.lines), total }
+}
+
+const writeSummary = async (summary: Summary, destination?: string) => {
+  if (!destination) {
+    console.log(JSON.stringify(summary, null, 2))
+    return
+  }
+  await fs.mkdir(path.dirname(destination), { recursive: true })
+  await fs.writeFile(destination, `${JSON.stringify(summary, null, 2)}\n`, 'utf8')
+  console.log(`Report written to ${destination}`)
+}
+
+const main = async () => {
+  const options = parseArgs()
+  const { reports, total } = await walkFiles(options)
+  const summary: Summary = {
+    root: options.root,
+    maxLines: options.maxLines,
+    ignored: Array.from(options.ignore).sort(),
+    scanned: total,
+    overLimit: reports.length,
+    timestamp: new Date().toISOString(),
+    files: reports,
+  }
+
+  await writeSummary(summary, options.outFile)
+}
+
+main().catch((error) => {
+  console.error('Failed to generate TypeScript file size report', error)
+  process.exit(1)
+})

--- a/tools/analysis/code/reports/large-ts-files.json
+++ b/tools/analysis/code/reports/large-ts-files.json
@@ -1,0 +1,550 @@
+{
+  "root": "/workspace/metabuilder",
+  "maxLines": 150,
+  "ignored": [
+    ".git",
+    ".next",
+    ".turbo",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "out",
+    "tmp"
+  ],
+  "scanned": 1381,
+  "overLimit": 106,
+  "timestamp": "2025-12-27T15:30:28.307Z",
+  "files": [
+    {
+      "path": "frontends/nextjs/src/lib/packages/core/package-catalog.ts",
+      "lines": 1170,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/github/GitHubActionsFetcher.tsx",
+      "lines": 1070,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/editors/lua/LuaBlocksEditor.tsx",
+      "lines": 1049,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/lua/snippets/lua-snippets-data.ts",
+      "lines": 984,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/editors/lua/LuaEditor.tsx",
+      "lines": 682,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/packages/tests/package-glue.test.ts",
+      "lines": 620,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/managers/package/PackageImportExport.tsx",
+      "lines": 595,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/workflow/WorkflowEditor.tsx",
+      "lines": 509,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/managers/package/PackageManager.tsx",
+      "lines": 492,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/rendering/page/page-definition-builder.ts",
+      "lines": 484,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/managers/component/ComponentHierarchyEditor.tsx",
+      "lines": 479,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/db/database-admin/seed-default-data.ts",
+      "lines": 472,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/schema/schema-utils.test.ts",
+      "lines": 441,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/demos/DBALDemo.tsx",
+      "lines": 429,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/blob/providers/filesystem-storage.ts",
+      "lines": 411,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/organisms/navigation/Pagination.tsx",
+      "lines": 407,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/workflow/engine/workflow-engine.test.ts",
+      "lines": 389,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/organisms/navigation/Navigation.tsx",
+      "lines": 372,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/blob/providers/s3-storage.ts",
+      "lines": 362,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/lua/engine/core/lua-engine.test.ts",
+      "lines": 358,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/rendering/tests/declarative-component-renderer.test.ts",
+      "lines": 356,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/organisms/dialogs/Command.tsx",
+      "lines": 353,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/adapters/prisma-adapter.ts",
+      "lines": 351,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/shared/tools/cpp-build-assistant.ts",
+      "lines": 343,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/components/component-catalog.ts",
+      "lines": 338,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/level/levels/Level3.tsx",
+      "lines": 336,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/managers/UserManagement.tsx",
+      "lines": 335,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "tools/analysis/test/analyze-test-coverage.ts",
+      "lines": 333,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/editors/schema/SchemaEditorLevel4.tsx",
+      "lines": 331,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/managers/css/CssClassManager.tsx",
+      "lines": 328,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/demos/IRCWebchatDeclarative.tsx",
+      "lines": 320,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/viewers/ModelListView.tsx",
+      "lines": 319,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/nerd-mode-ide/core/NerdModeIDE.tsx",
+      "lines": 318,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/managers/css/CssClassBuilder.tsx",
+      "lines": 316,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/dbal/core/client/dbal-integration.ts",
+      "lines": 314,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/organisms/navigation/Sidebar.tsx",
+      "lines": 311,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/schema/default-schema.ts",
+      "lines": 309,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/core/foundation/kv-store.ts",
+      "lines": 308,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/data/QuickGuide.tsx",
+      "lines": 298,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "tools/analysis/code/analyze-render-performance.ts",
+      "lines": 295,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/editors/ThemeEditor.tsx",
+      "lines": 295,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/managers/PageRoutesManager.tsx",
+      "lines": 291,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/managers/component/ComponentConfigDialog.tsx",
+      "lines": 291,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/level/levels/Level5.tsx",
+      "lines": 290,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/editors/lua/LuaSnippetLibrary.tsx",
+      "lines": 286,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/data/GenericPage.tsx",
+      "lines": 275,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/demos/IRCWebchat.tsx",
+      "lines": 272,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/organisms/dialogs/AlertDialog.tsx",
+      "lines": 270,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/hooks/ui/state/useAutoRefresh.test.ts",
+      "lines": 269,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/molecules/overlay/DropdownMenu.tsx",
+      "lines": 269,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/nerd-mode-ide/templates/template-configs.ts",
+      "lines": 268,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/rendering/tests/page-renderer.test.ts",
+      "lines": 266,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/index.ts",
+      "lines": 264,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/blob/providers/tenant-aware-storage.ts",
+      "lines": 261,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/examples/ContactForm.example.tsx",
+      "lines": 259,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/adapters/acl-adapter.ts",
+      "lines": 259,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/security/scanner/security-scanner.test.ts",
+      "lines": 258,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/organisms/dialogs/Sheet.tsx",
+      "lines": 256,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/managers/database/DatabaseManager.tsx",
+      "lines": 256,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "tools/misc/metrics/enforce-size-limits.ts",
+      "lines": 250,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/organisms/security/SecurityWarningDialog.tsx",
+      "lines": 248,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/app/codegen/CodegenStudioClient.tsx",
+      "lines": 240,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/demos/ScreenshotAnalyzer.tsx",
+      "lines": 234,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/rendering/RenderComponent.tsx",
+      "lines": 232,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "tools/analysis/test/analyze-implementation-completeness.ts",
+      "lines": 231,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/blob/providers/memory-storage.ts",
+      "lines": 231,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/sonner.tsx",
+      "lines": 228,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/managers/DropdownConfigManager.tsx",
+      "lines": 227,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/auth/UnifiedLogin.tsx",
+      "lines": 221,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/rendering/PropertyInspector.tsx",
+      "lines": 218,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/db/core/index.ts",
+      "lines": 217,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/core/foundation/types.ts",
+      "lines": 217,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "tools/detection/detect-stub-implementations.ts",
+      "lines": 216,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/level/levels/Level1.tsx",
+      "lines": 213,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/organisms/data/Form.tsx",
+      "lines": 211,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/rendering/FieldRenderer.tsx",
+      "lines": 211,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/molecules/overlay/DropdownMenu.tsx",
+      "lines": 208,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/level5/tabs/PowerTransferTab.tsx",
+      "lines": 208,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "tools/generation/generate-stub-report.ts",
+      "lines": 205,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/auth/GodCredentialsSettings.tsx",
+      "lines": 204,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/level/panels/ModeratorPanel.tsx",
+      "lines": 202,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/theme/types/theme.d.ts",
+      "lines": 201,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/hooks/data/useKV.test.ts",
+      "lines": 197,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/editors/JsonEditor.tsx",
+      "lines": 197,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/molecules/overlay/Dialog.tsx",
+      "lines": 192,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/level/levels/Level2.tsx",
+      "lines": 191,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/molecules/overlay/Dialog.tsx",
+      "lines": 189,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/viewers/AuditLogViewer.tsx",
+      "lines": 189,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/core/entities/operations/system/package-operations.ts",
+      "lines": 186,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/core/entities/operations/core/user-operations.ts",
+      "lines": 186,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/security/functions/patterns/javascript-patterns.ts",
+      "lines": 185,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/misc/data/SMTPConfigEditor.tsx",
+      "lines": 185,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/hooks/useAuth.test.ts",
+      "lines": 182,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/rendering/page/page-renderer.ts",
+      "lines": 179,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/level4/Level4Tabs.tsx",
+      "lines": 178,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "tools/quality/code/check-code-complexity.ts",
+      "lines": 176,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/ui/organisms/data/Table.tsx",
+      "lines": 175,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "dbal/development/src/bridges/websocket-bridge.ts",
+      "lines": 169,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/lib/github/workflows/analysis/runs/analyze-workflow-runs.ts",
+      "lines": 165,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/app/levels/LevelsClient.tsx",
+      "lines": 165,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/rendering/Builder.tsx",
+      "lines": 164,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/molecules/form/Select.tsx",
+      "lines": 161,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "tools/generation/generate-quality-summary.ts",
+      "lines": 160,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "tools/analysis/code/list-large-typescript-files.ts",
+      "lines": 159,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/components/level/levels/Level4.tsx",
+      "lines": 156,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    },
+    {
+      "path": "frontends/nextjs/src/types/dbal.d.ts",
+      "lines": 155,
+      "recommendation": "Split into focused modules; keep one primary lambda per file and extract helpers."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a tsx-based analyzer that lists TypeScript/TSX files above a configurable line threshold
- document the lambda-per-file refactor approach and how to run the analyzer
- generate an initial report of oversized TypeScript files to drive follow-up refactors

## Testing
- npx tsx tools/analysis/code/list-large-typescript-files.ts --max-lines 150 --out tools/analysis/code/reports/large-ts-files.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ffafdcd2c833197580b6fb5b04f7e)