### PR TITLE
feat: add dbal client builders and integration entry

### DIFF
--- a/dbal/development/src/core/client.ts
+++ b/dbal/development/src/core/client.ts
@@ -1,0 +1,8 @@
+import type { DBALConfig } from '../runtime/config'
+import { DBALClient } from './client/client'
+export { buildAdapter, buildEntityOperations } from './client/builders'
+export { normalizeClientConfig, validateClientConfig } from './client/mappers'
+
+export const createDBALClient = (config: DBALConfig) => new DBALClient(config)
+
+export { DBALClient }

--- a/dbal/development/src/core/client/builders.ts
+++ b/dbal/development/src/core/client/builders.ts
@@ -1,0 +1,24 @@
+import type { DBALAdapter } from '../../adapters/adapter'
+import type { DBALConfig } from '../../runtime/config'
+import { createAdapter } from './adapter-factory'
+import {
+  createComponentOperations,
+  createLuaScriptOperations,
+  createPackageOperations,
+  createPageOperations,
+  createSessionOperations,
+  createUserOperations,
+  createWorkflowOperations
+} from '../entities'
+
+export const buildAdapter = (config: DBALConfig): DBALAdapter => createAdapter(config)
+
+export const buildEntityOperations = (adapter: DBALAdapter) => ({
+  users: createUserOperations(adapter),
+  pages: createPageOperations(adapter),
+  components: createComponentOperations(adapter),
+  workflows: createWorkflowOperations(adapter),
+  luaScripts: createLuaScriptOperations(adapter),
+  packages: createPackageOperations(adapter),
+  sessions: createSessionOperations(adapter)
+})

--- a/dbal/development/src/core/client/client.ts
+++ b/dbal/development/src/core/client/client.ts
@@ -1,7 +1,7 @@
 /**
  * @file client.ts
  * @description DBAL Client - Main interface for database operations
- * 
+ *
  * Provides CRUD operations for all entities through modular operation handlers.
  * Each entity type has its own dedicated operations module following the
  * single-responsibility pattern.
@@ -9,82 +9,67 @@
 
 import type { DBALConfig } from '../../runtime/config'
 import type { DBALAdapter } from '../../adapters/adapter'
-import { createAdapter } from './adapter-factory'
-import {
-  createUserOperations,
-  createPageOperations,
-  createComponentOperations,
-  createWorkflowOperations,
-  createLuaScriptOperations,
-  createPackageOperations,
-  createSessionOperations,
-} from '../entities'
+import { buildAdapter, buildEntityOperations } from './builders'
+import { normalizeClientConfig, validateClientConfig } from './mappers'
 
 export class DBALClient {
   private adapter: DBALAdapter
   private config: DBALConfig
+  private operations: ReturnType<typeof buildEntityOperations>
 
   constructor(config: DBALConfig) {
-    this.config = config
-    
-    // Validate configuration
-    if (!config.adapter) {
-      throw new Error('Adapter type must be specified')
-    }
-    if (config.mode !== 'production' && !config.database?.url) {
-      throw new Error('Database URL must be specified for non-production mode')
-    }
-    
-    this.adapter = createAdapter(config)
+    this.config = normalizeClientConfig(validateClientConfig(config))
+    this.adapter = buildAdapter(this.config)
+    this.operations = buildEntityOperations(this.adapter)
   }
 
   /**
    * User entity operations
    */
   get users() {
-    return createUserOperations(this.adapter)
+    return this.operations.users
   }
 
   /**
    * Page entity operations
    */
   get pages() {
-    return createPageOperations(this.adapter)
+    return this.operations.pages
   }
 
   /**
    * Component hierarchy entity operations
    */
   get components() {
-    return createComponentOperations(this.adapter)
+    return this.operations.components
   }
 
   /**
    * Workflow entity operations
    */
   get workflows() {
-    return createWorkflowOperations(this.adapter)
+    return this.operations.workflows
   }
 
   /**
    * Lua script entity operations
    */
   get luaScripts() {
-    return createLuaScriptOperations(this.adapter)
+    return this.operations.luaScripts
   }
 
   /**
    * Package entity operations
    */
   get packages() {
-    return createPackageOperations(this.adapter)
+    return this.operations.packages
   }
 
   /**
    * Session entity operations
    */
   get sessions() {
-    return createSessionOperations(this.adapter)
+    return this.operations.sessions
   }
 
   /**

--- a/dbal/development/src/core/client/mappers.ts
+++ b/dbal/development/src/core/client/mappers.ts
@@ -1,0 +1,25 @@
+import type { DBALConfig } from '../../runtime/config'
+import { DBALError } from '../foundation/errors'
+
+export const validateClientConfig = (config: DBALConfig): DBALConfig => {
+  if (!config.adapter) {
+    throw DBALError.validationError('Adapter type must be specified', [])
+  }
+
+  if (config.mode !== 'production' && !config.database?.url) {
+    throw DBALError.validationError('Database URL must be specified for non-production mode', [])
+  }
+
+  return config
+}
+
+export const normalizeClientConfig = (config: DBALConfig): DBALConfig => ({
+  ...config,
+  security: {
+    sandbox: config.security?.sandbox ?? 'strict',
+    enableAuditLog: config.security?.enableAuditLog ?? true
+  },
+  performance: {
+    ...config.performance
+  }
+})

--- a/dbal/development/src/index.ts
+++ b/dbal/development/src/index.ts
@@ -1,4 +1,4 @@
-export { DBALClient } from './core/client/client'
+export { DBALClient, createDBALClient } from './core/client'
 export type { DBALConfig } from './runtime/config'
 export type * from './core/foundation/types'
 export { DBALError, DBALErrorCode } from './core/foundation/errors'


### PR DESCRIPTION
## Summary
- add client builders to compose adapters and entity operations
- validate and normalize DBAL client configuration through dedicated mappers
- provide a short integration entrypoint that exposes DBAL client creation helpers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69502aaeea54833196660733c7b59313)