### PR TITLE
test: reorganize hook tests

### DIFF
--- a/frontends/nextjs/src/hooks/data/__tests__/useKV.store.test.ts
+++ b/frontends/nextjs/src/hooks/data/__tests__/useKV.store.test.ts
@@ -1,54 +1,34 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
-import { useKV } from '@/hooks/useKV'
+import { useKV } from '@/hooks/data/useKV'
 
-describe('useKV', () => {
-  const STORAGE_PREFIX = 'mb_kv:'
-  let store: Record<string, string>
+const STORAGE_PREFIX = 'mb_kv:'
+let store: Record<string, string>
 
+const setupLocalStorage = (): void => {
+  store = {}
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key]
+    }),
+    clear: vi.fn(() => {
+      Object.keys(store).forEach(k => delete store[k])
+    }),
+    length: 0,
+    key: vi.fn(() => null),
+  })
+}
+
+describe('useKV storage', () => {
   beforeEach(() => {
-    // Mock localStorage
-    store = {}
-    vi.stubGlobal('localStorage', {
-      getItem: vi.fn((key: string) => store[key] ?? null),
-      setItem: vi.fn((key: string, value: string) => { store[key] = value }),
-      removeItem: vi.fn((key: string) => { delete store[key] }),
-      clear: vi.fn(() => { Object.keys(store).forEach(k => delete store[k]) }),
-      length: 0,
-      key: vi.fn(() => null),
-    })
+    setupLocalStorage()
   })
 
-  it.each([
-    { key: 'user_name', defaultValue: 'John', description: 'string value' },
-    { key: 'user_count', defaultValue: 0, description: 'number value' },
-    { key: 'is_active', defaultValue: true, description: 'boolean value' },
-    { key: 'user_data', defaultValue: { id: 1, name: 'John' }, description: 'object value' },
-  ])('should initialize hook with $description', ({ key, defaultValue }) => {
-    const { result } = renderHook(() => useKV(key, defaultValue))
-    const [value] = result.current
-
-    expect(value).toBe(defaultValue)
-  })
-
-  it('should initialize with undefined when no default value provided', () => {
-    const { result } = renderHook(() => useKV('empty_key'))
-    const [value] = result.current
-
-    expect(value).toBeUndefined()
-  })
-
-  it('should load value from localStorage when available', async () => {
-    localStorage.setItem(`${STORAGE_PREFIX}stored_key`, JSON.stringify('stored'))
-
-    const { result } = renderHook(() => useKV('stored_key', 'default'))
-
-    await waitFor(() => {
-      expect(result.current[0]).toBe('stored')
-    })
-  })
-
-  it('should migrate legacy localStorage entries to namespaced keys', () => {
+  it('migrates legacy localStorage entries to namespaced keys', () => {
     localStorage.setItem('legacy_key', JSON.stringify('legacy'))
 
     const { result } = renderHook(() => useKV('legacy_key', 'default'))
@@ -58,7 +38,7 @@ describe('useKV', () => {
     expect(localStorage.getItem('legacy_key')).toBeNull()
   })
 
-  it('should update value when using updater function', async () => {
+  it('updates value when using updater function', async () => {
     const { result } = renderHook(() => useKV('counter', 0))
 
     const [, updateValue] = result.current
@@ -71,9 +51,8 @@ describe('useKV', () => {
     expect(newValue).toBe(1)
   })
 
-  it('should update value when providing direct value', async () => {
+  it('updates value when providing direct value', async () => {
     const { result } = renderHook(() => useKV('name', 'John'))
-
     const [, updateValue] = result.current
 
     await act(async () => {
@@ -84,7 +63,7 @@ describe('useKV', () => {
     expect(newValue).toBe('Jane')
   })
 
-  it('should handle complex object updates', async () => {
+  it('handles complex object updates', async () => {
     const initialObject = { id: 1, name: 'John', email: 'john@example.com' }
     const { result } = renderHook(() => useKV('user', initialObject))
 
@@ -101,7 +80,7 @@ describe('useKV', () => {
     expect(newValue).toEqual({ id: 1, name: 'Jane', email: 'john@example.com' })
   })
 
-  it('should handle array updates', async () => {
+  it('handles array updates', async () => {
     const initialArray = [1, 2, 3]
     const { result } = renderHook(() => useKV('items', initialArray))
 
@@ -115,7 +94,7 @@ describe('useKV', () => {
     expect(newValue).toEqual([1, 2, 3, 4])
   })
 
-  it('should maintain separate state for different keys', async () => {
+  it('maintains separate state for different keys', () => {
     const { result: result1 } = renderHook(() => useKV('key1', 'value1'))
     const { result: result2 } = renderHook(() => useKV('key2', 'value2'))
 
@@ -126,7 +105,7 @@ describe('useKV', () => {
     expect(value2).toBe('value2')
   })
 
-  it('should persist updates across multiple hooks with same key', async () => {
+  it('persists updates across multiple hooks with same key', async () => {
     const { result: firstHook } = renderHook(() => useKV('shared_key', 'initial'))
     const [, updateValue] = firstHook.current
 
@@ -134,14 +113,13 @@ describe('useKV', () => {
       await updateValue('updated')
     })
 
-    // Create a new hook with the same key
     const { result: secondHook } = renderHook(() => useKV('shared_key', 'initial'))
     const [value] = secondHook.current
 
     expect(value).toBe('updated')
   })
 
-  it('should sync updates across mounted hooks with same key', async () => {
+  it('syncs updates across mounted hooks with same key', async () => {
     const { result: firstHook } = renderHook(() => useKV('sync_key', 'initial'))
     const { result: secondHook } = renderHook(() => useKV('sync_key', 'initial'))
 
@@ -154,19 +132,7 @@ describe('useKV', () => {
     })
   })
 
-  it.each([
-    { initialValue: null, key: 'falsy_key_null', description: 'null value' },
-    { initialValue: false, key: 'falsy_key_false', description: 'false boolean' },
-    { initialValue: 0, key: 'falsy_key_zero', description: 'zero number' },
-    { initialValue: '', key: 'falsy_key_empty', description: 'empty string' },
-  ])('should handle falsy $description correctly', ({ initialValue, key }) => {
-    const { result } = renderHook(() => useKV(key, initialValue))
-    const [value] = result.current
-
-    expect(value).toBe(initialValue)
-  })
-
-  it('should handle rapid updates correctly', async () => {
+  it('handles rapid updates correctly', async () => {
     const { result } = renderHook(() => useKV('rapid_key', 0))
     const [, updateValue] = result.current
 
@@ -183,7 +149,7 @@ describe('useKV', () => {
     expect(finalValue).toBeGreaterThanOrEqual(1)
   })
 
-  it('should persist updates to localStorage', async () => {
+  it('persists updates to localStorage', async () => {
     const { result } = renderHook(() => useKV('persist_key', 'initial'))
     const [, updateValue] = result.current
 

--- a/frontends/nextjs/src/hooks/data/__tests__/useKV.validation.test.ts
+++ b/frontends/nextjs/src/hooks/data/__tests__/useKV.validation.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useKV } from '@/hooks/data/useKV'
+
+const STORAGE_PREFIX = 'mb_kv:'
+let store: Record<string, string>
+
+const setupLocalStorage = (): void => {
+  store = {}
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key]
+    }),
+    clear: vi.fn(() => {
+      Object.keys(store).forEach(k => delete store[k])
+    }),
+    length: 0,
+    key: vi.fn(() => null),
+  })
+}
+
+describe('useKV validation', () => {
+  beforeEach(() => {
+    setupLocalStorage()
+  })
+
+  it.each([
+    { key: 'user_name', defaultValue: 'John', description: 'string value' },
+    { key: 'user_count', defaultValue: 0, description: 'number value' },
+    { key: 'is_active', defaultValue: true, description: 'boolean value' },
+    { key: 'user_data', defaultValue: { id: 1, name: 'John' }, description: 'object value' },
+  ])('initializes with $description', ({ key, defaultValue }) => {
+    const { result } = renderHook(() => useKV(key, defaultValue))
+    const [value] = result.current
+
+    expect(value).toBe(defaultValue)
+  })
+
+  it('initializes with undefined when no default value provided', () => {
+    const { result } = renderHook(() => useKV('empty_key'))
+    const [value] = result.current
+
+    expect(value).toBeUndefined()
+  })
+
+  it.each([
+    { initialValue: null, key: 'falsy_key_null', description: 'null value' },
+    { initialValue: false, key: 'falsy_key_false', description: 'false boolean' },
+    { initialValue: 0, key: 'falsy_key_zero', description: 'zero number' },
+    { initialValue: '', key: 'falsy_key_empty', description: 'empty string' },
+  ])('handles $description correctly', ({ initialValue, key }) => {
+    const { result } = renderHook(() => useKV(key, initialValue))
+    const [value] = result.current
+
+    expect(value).toBe(initialValue)
+  })
+
+  it('loads value from localStorage when available', () => {
+    localStorage.setItem(`${STORAGE_PREFIX}stored_key`, JSON.stringify('stored'))
+
+    const { result } = renderHook(() => useKV('stored_key', 'default'))
+    const [value] = result.current
+
+    expect(value).toBe('stored')
+  })
+})

--- a/frontends/nextjs/src/hooks/ui/state/__tests__/useAutoRefresh.error-handling.test.ts
+++ b/frontends/nextjs/src/hooks/ui/state/__tests__/useAutoRefresh.error-handling.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Auto-refresh error-handling tests
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAutoRefresh } from '../useAutoRefresh'
+
+describe('useAutoRefresh error handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stops refresh when disabled after being enabled', () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined)
+
+    const { result } = renderHook(() =>
+      useAutoRefresh({
+        intervalMs: 5000,
+        onRefresh,
+        enabled: true,
+      })
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+
+    act(() => {
+      result.current.setEnabled(false)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(10000)
+    })
+
+    expect(onRefresh).not.toHaveBeenCalled()
+  })
+
+  it('continues scheduling refreshes after onRefresh errors', () => {
+    const erroringRefresh = vi.fn().mockImplementation(() =>
+      Promise.reject(new Error('refresh failed')).catch(() => {})
+    )
+
+    const { result } = renderHook(() =>
+      useAutoRefresh({
+        intervalMs: 2000,
+        onRefresh: erroringRefresh,
+        enabled: true,
+      })
+    )
+
+    expect(result.current.secondsUntilNextRefresh).toBe(2)
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(erroringRefresh).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current.secondsUntilNextRefresh).toBe(1)
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current.secondsUntilNextRefresh).toBe(2)
+    expect(erroringRefresh).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontends/nextjs/src/hooks/ui/state/__tests__/useAutoRefresh.polling.test.ts
+++ b/frontends/nextjs/src/hooks/ui/state/__tests__/useAutoRefresh.polling.test.ts
@@ -1,13 +1,11 @@
 /**
- * Tests for useAutoRefresh hook - Auto-refresh polling management
- * Following parameterized test pattern per project conventions
+ * Auto-refresh polling tests
  */
-
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
-import { useAutoRefresh } from './useAutoRefresh'
+import { useAutoRefresh } from '../useAutoRefresh'
 
-describe('useAutoRefresh', () => {
+describe('useAutoRefresh polling', () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })
@@ -21,7 +19,7 @@ describe('useAutoRefresh', () => {
       { enabled: false, expectAutoRefreshing: false },
       { enabled: true, expectAutoRefreshing: true },
       { enabled: undefined, expectAutoRefreshing: false },
-    ])('should initialize with enabled=$enabled -> isAutoRefreshing=$expectAutoRefreshing', ({ enabled, expectAutoRefreshing }) => {
+    ])('initializes with enabled=$enabled -> isAutoRefreshing=$expectAutoRefreshing', ({ enabled, expectAutoRefreshing }) => {
       const onRefresh = vi.fn().mockResolvedValue(undefined)
 
       const { result } = renderHook(() =>
@@ -39,7 +37,7 @@ describe('useAutoRefresh', () => {
       { intervalMs: 30000, expectedSeconds: 30 },
       { intervalMs: 60000, expectedSeconds: 60 },
       { intervalMs: 5000, expectedSeconds: 5 },
-    ])('should set secondsUntilNextRefresh from intervalMs=$intervalMs', ({ intervalMs, expectedSeconds }) => {
+    ])('sets secondsUntilNextRefresh from intervalMs=$intervalMs', ({ intervalMs, expectedSeconds }) => {
       const onRefresh = vi.fn().mockResolvedValue(undefined)
 
       const { result } = renderHook(() =>
@@ -55,7 +53,7 @@ describe('useAutoRefresh', () => {
   })
 
   describe('toggleAutoRefresh', () => {
-    it('should toggle from disabled to enabled', () => {
+    it('toggles from disabled to enabled', () => {
       const onRefresh = vi.fn().mockResolvedValue(undefined)
 
       const { result } = renderHook(() =>
@@ -75,7 +73,7 @@ describe('useAutoRefresh', () => {
       expect(result.current.isAutoRefreshing).toBe(true)
     })
 
-    it('should toggle from enabled to disabled', () => {
+    it('toggles from enabled to disabled', () => {
       const onRefresh = vi.fn().mockResolvedValue(undefined)
 
       const { result } = renderHook(() =>
@@ -102,7 +100,7 @@ describe('useAutoRefresh', () => {
       { initial: true, setTo: false, expected: false },
       { initial: false, setTo: false, expected: false },
       { initial: true, setTo: true, expected: true },
-    ])('should set from $initial to $setTo', ({ initial, setTo, expected }) => {
+    ])('sets from $initial to $setTo', ({ initial, setTo, expected }) => {
       const onRefresh = vi.fn().mockResolvedValue(undefined)
 
       const { result } = renderHook(() =>
@@ -122,7 +120,7 @@ describe('useAutoRefresh', () => {
   })
 
   describe('refresh timing', () => {
-    it('should call onRefresh after intervalMs when enabled', async () => {
+    it('calls onRefresh after intervalMs when enabled', async () => {
       const onRefresh = vi.fn().mockResolvedValue(undefined)
 
       renderHook(() =>
@@ -133,23 +131,20 @@ describe('useAutoRefresh', () => {
         })
       )
 
-      // Not called initially
       expect(onRefresh).not.toHaveBeenCalled()
 
-      // Advance to just before interval
       act(() => {
         vi.advanceTimersByTime(4999)
       })
       expect(onRefresh).not.toHaveBeenCalled()
 
-      // Advance past interval
       act(() => {
         vi.advanceTimersByTime(1)
       })
       expect(onRefresh).toHaveBeenCalledTimes(1)
     })
 
-    it('should not call onRefresh when disabled', () => {
+    it('does not call onRefresh when disabled', () => {
       const onRefresh = vi.fn().mockResolvedValue(undefined)
 
       renderHook(() =>
@@ -167,7 +162,7 @@ describe('useAutoRefresh', () => {
       expect(onRefresh).not.toHaveBeenCalled()
     })
 
-    it('should call onRefresh multiple times at interval', () => {
+    it('calls onRefresh multiple times at interval', () => {
       const onRefresh = vi.fn().mockResolvedValue(undefined)
 
       renderHook(() =>
@@ -179,7 +174,7 @@ describe('useAutoRefresh', () => {
       )
 
       act(() => {
-        vi.advanceTimersByTime(15000) // 3 intervals
+        vi.advanceTimersByTime(15000)
       })
 
       expect(onRefresh).toHaveBeenCalledTimes(3)
@@ -187,7 +182,7 @@ describe('useAutoRefresh', () => {
   })
 
   describe('countdown', () => {
-    it('should decrement countdown every second when enabled', () => {
+    it('decrements countdown every second when enabled', () => {
       const onRefresh = vi.fn().mockResolvedValue(undefined)
 
       const { result } = renderHook(() =>
@@ -211,7 +206,7 @@ describe('useAutoRefresh', () => {
       expect(result.current.secondsUntilNextRefresh).toBe(3)
     })
 
-    it('should reset countdown after reaching zero', () => {
+    it('resets countdown after reaching zero', () => {
       const onRefresh = vi.fn().mockResolvedValue(undefined)
 
       const { result } = renderHook(() =>
@@ -224,45 +219,11 @@ describe('useAutoRefresh', () => {
 
       expect(result.current.secondsUntilNextRefresh).toBe(3)
 
-      // Advance 3 seconds to reach zero
       act(() => {
         vi.advanceTimersByTime(3000)
       })
 
-      // Should reset to initial value
       expect(result.current.secondsUntilNextRefresh).toBe(3)
-    })
-  })
-
-  describe('cleanup', () => {
-    it('should stop refresh when disabled after being enabled', () => {
-      const onRefresh = vi.fn().mockResolvedValue(undefined)
-
-      const { result } = renderHook(() =>
-        useAutoRefresh({
-          intervalMs: 5000,
-          onRefresh,
-          enabled: true,
-        })
-      )
-
-      // Advance half interval
-      act(() => {
-        vi.advanceTimersByTime(2500)
-      })
-
-      // Disable
-      act(() => {
-        result.current.setEnabled(false)
-      })
-
-      // Advance another full interval
-      act(() => {
-        vi.advanceTimersByTime(10000)
-      })
-
-      // Should not have been called (disabled before first interval completed)
-      expect(onRefresh).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Summary
- split useKV coverage into dedicated validation and storage test suites
- separate auto refresh polling and error handling cases into scoped test files
- reorganize useAuth tests into session and role mapping suites

## Testing
- npm run test:unit -- src/hooks/data/__tests__/useKV.store.test.ts src/hooks/data/__tests__/useKV.validation.test.ts src/hooks/ui/state/__tests__/useAutoRefresh.polling.test.ts src/hooks/ui/state/__tests__/useAutoRefresh.error-handling.test.ts src/hooks/__tests__/useAuth.session.test.ts src/hooks/__tests__/useAuth.roles.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69502aa77f948331ae8800927e1aa84f)