### PR TITLE
Fix type lint warnings in hooks

### DIFF
--- a/frontends/nextjs/src/hooks/auth/auth-store.ts
+++ b/frontends/nextjs/src/hooks/auth/auth-store.ts
@@ -38,7 +38,7 @@ export class AuthStore {
   }
 
   async ensureSessionChecked(): Promise<void> {
-    if (!this.sessionCheckPromise) {
+    if (this.sessionCheckPromise === null) {
       this.sessionCheckPromise = this.refresh().finally(() => {
         this.sessionCheckPromise = null
       })
@@ -129,6 +129,7 @@ export class AuthStore {
         isAuthenticated: false,
         isLoading: false,
       })
+      console.error('Failed to refresh session', error)
     }
   }
 }

--- a/frontends/nextjs/src/hooks/ui/state/__tests__/useAutoRefresh.polling.test.ts
+++ b/frontends/nextjs/src/hooks/ui/state/__tests__/useAutoRefresh.polling.test.ts
@@ -1,7 +1,7 @@
 /**
  * Auto-refresh polling tests
  */
-import { act, renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAutoRefresh } from '../useAutoRefresh'

--- a/frontends/nextjs/src/hooks/ui/state/useAutoRefresh.ts
+++ b/frontends/nextjs/src/hooks/ui/state/useAutoRefresh.ts
@@ -34,7 +34,7 @@ export function useAutoRefresh({
     if (!isAutoRefreshing) return
 
     const refreshInterval = setInterval(() => {
-      onRefresh()
+      void onRefresh()
     }, intervalMs)
 
     const countdownInterval = setInterval(() => {

--- a/frontends/nextjs/src/hooks/use-dbal/use-dbal.ts
+++ b/frontends/nextjs/src/hooks/use-dbal/use-dbal.ts
@@ -23,7 +23,7 @@ export function useDBAL() {
       }
     }
 
-    init()
+    void init()
   }, [])
 
   return { isReady, error }

--- a/frontends/nextjs/src/hooks/use-dbal/use-kv-store.ts
+++ b/frontends/nextjs/src/hooks/use-dbal/use-kv-store.ts
@@ -12,7 +12,7 @@ export function useKVStore(tenantId: string = 'default', userId: string = 'syste
   const { isReady } = useDBAL()
 
   const set = useCallback(
-    async (key: string, value: any, ttl?: number) => {
+    async (key: string, value: unknown, ttl?: number) => {
       if (!isReady) {
         throw new Error('DBAL not ready')
       }
@@ -28,7 +28,7 @@ export function useKVStore(tenantId: string = 'default', userId: string = 'syste
   )
 
   const get = useCallback(
-    async <T = any>(key: string): Promise<T | null> => {
+    async <T = unknown>(key: string): Promise<T | null> => {
       if (!isReady) {
         throw new Error('DBAL not ready')
       }
@@ -60,7 +60,7 @@ export function useKVStore(tenantId: string = 'default', userId: string = 'syste
   )
 
   const listAdd = useCallback(
-    async (key: string, items: any[]) => {
+    async <T = unknown>(key: string, items: T[]) => {
       if (!isReady) {
         throw new Error('DBAL not ready')
       }
@@ -76,7 +76,7 @@ export function useKVStore(tenantId: string = 'default', userId: string = 'syste
   )
 
   const listGet = useCallback(
-    async (key: string, start?: number, end?: number): Promise<any[]> => {
+    async <T = unknown>(key: string, start?: number, end?: number): Promise<T[]> => {
       if (!isReady) {
         throw new Error('DBAL not ready')
       }


### PR DESCRIPTION
## Summary
- prevent unhandled promises and stale dependencies in auto refresh and DBAL hooks
- strengthen KV store typing to satisfy lint rules
- clean up auth store error handling and unused test imports

## Testing
- npx eslint src/hooks/ui/state/useAutoRefresh.ts src/hooks/ui/state/__tests__/useAutoRefresh.polling.test.ts src/hooks/ui/useFileTree.ts src/hooks/use-dbal/use-cached-data.ts src/hooks/use-dbal/use-dbal.ts src/hooks/use-dbal/use-kv-store.ts src/hooks/auth/auth-store.ts --max-warnings=0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530d1deefc8331a56749af774ddaab)