### PR TITLE
Improve package data typings

### DIFF
--- a/frontends/nextjs/src/lib/api/packages/data/get-package-data.ts
+++ b/frontends/nextjs/src/lib/api/packages/data/get-package-data.ts
@@ -1,7 +1,8 @@
 import { requestJson } from '@/lib/api/request-json'
+import { type PackageSeedData } from '@/lib/packages/core/package-types'
 
-export async function getPackageData(packageId: string): Promise<Record<string, any[]>> {
-  const payload = await requestJson<{ data: Record<string, any[]> }>(
+export async function getPackageData(packageId: string): Promise<PackageSeedData> {
+  const payload = await requestJson<{ data: PackageSeedData }>(
     `/api/packages/data/${packageId}`
   )
   return payload.data

--- a/frontends/nextjs/src/lib/api/packages/data/set-package-data.ts
+++ b/frontends/nextjs/src/lib/api/packages/data/set-package-data.ts
@@ -1,8 +1,9 @@
 import { requestJson } from '@/lib/api/request-json'
+import { type PackageSeedData } from '@/lib/packages/core/package-types'
 
 export async function setPackageData(
   packageId: string,
-  data: Record<string, any[]>
+  data: PackageSeedData
 ): Promise<void> {
   await requestJson<{ saved: boolean }>(`/api/packages/data/${packageId}`, {
     method: 'PUT',

--- a/frontends/nextjs/src/lib/db/core/types.ts
+++ b/frontends/nextjs/src/lib/db/core/types.ts
@@ -34,8 +34,8 @@ export interface ComponentNode {
 export interface ComponentConfig {
   id: string
   componentId: string
-  props: Record<string, any>
-  styles: Record<string, any>
+  props: Record<string, unknown>
+  styles: Record<string, unknown>
   events: Record<string, string>
   conditionalRendering?: {
     condition: string

--- a/frontends/nextjs/src/lib/db/packages/data/get/get-package-data.ts
+++ b/frontends/nextjs/src/lib/db/packages/data/get/get-package-data.ts
@@ -1,13 +1,14 @@
+import { type PackageSeedData } from '../../../../packages/core/package-types'
 import { getAdapter } from '../../../core/dbal-client'
 
 /**
  * Get package data for a specific package
  */
-export async function getPackageData(packageId: string): Promise<Record<string, any[]>> {
+export async function getPackageData(packageId: string): Promise<PackageSeedData> {
   const adapter = getAdapter()
   const pkg = (await adapter.findFirst('PackageData', {
     where: { packageId },
   })) as { data: string } | null
   if (!pkg) return {}
-  return JSON.parse(pkg.data)
+  return JSON.parse(pkg.data) as PackageSeedData
 }

--- a/frontends/nextjs/src/lib/db/packages/data/set-package-data.ts
+++ b/frontends/nextjs/src/lib/db/packages/data/set-package-data.ts
@@ -1,11 +1,12 @@
 import { getAdapter } from '../../core/dbal-client'
+import { type PackageSeedData } from '../../packages/core/package-types'
 
 /**
  * Set package data (upsert)
  */
 export async function setPackageData(
   packageId: string,
-  data: Record<string, any[]>
+  data: PackageSeedData
 ): Promise<void> {
   const adapter = getAdapter()
   await adapter.upsert('PackageData', {

--- a/frontends/nextjs/src/lib/packages/core/package-types.ts
+++ b/frontends/nextjs/src/lib/packages/core/package-types.ts
@@ -24,16 +24,20 @@ export interface PackageManifest {
 }
 
 export interface PackageContent {
-  schemas: any[]
-  pages: any[]
-  workflows: any[]
-  luaScripts: any[]
-  componentHierarchy: Record<string, any>
-  componentConfigs: Record<string, any>
-  cssClasses?: any[]
-  dropdownConfigs?: any[]
-  seedData?: Record<string, any[]>
+  schemas: unknown[]
+  pages: unknown[]
+  workflows: unknown[]
+  luaScripts: unknown[]
+  componentHierarchy: Record<string, unknown>
+  componentConfigs: Record<string, unknown>
+  cssClasses?: unknown[]
+  dropdownConfigs?: unknown[]
+  seedData?: PackageSeedData
 }
+
+export type PackageSeedRecord = Record<string, unknown>
+
+export type PackageSeedData = Record<string, PackageSeedRecord[]>
 
 export interface LuaScriptFile {
   name: string

--- a/frontends/nextjs/src/lib/types/builder-types.ts
+++ b/frontends/nextjs/src/lib/types/builder-types.ts
@@ -39,7 +39,7 @@ export type ComponentType =
  * @example { className: "mt-4", disabled: true, onClick: fn }
  */
 export interface ComponentProps {
-  [key: string]: any
+  [key: string]: unknown
 }
 
 /**
@@ -85,7 +85,7 @@ export interface PropDefinition {
   name: string
   label: string
   type: 'string' | 'number' | 'boolean' | 'select' | 'color' | 'dynamic-select'
-  defaultValue?: any
+  defaultValue?: unknown
   options?: Array<{ value: string; label: string }>
   dynamicSource?: string
   description?: string

--- a/frontends/nextjs/src/lib/types/level-types.ts
+++ b/frontends/nextjs/src/lib/types/level-types.ts
@@ -1,3 +1,5 @@
+import type { ModelSchema } from './schema-types'
+
 /**
  * UserRole - User permission levels in MetaBuilder
  * @description Six-level permission hierarchy
@@ -58,7 +60,7 @@ export interface WorkflowNode {
   id: string
   type: 'trigger' | 'action' | 'condition' | 'lua' | 'transform'
   label: string
-  config: Record<string, any>
+  config: Record<string, unknown>
   position: { x: number; y: number }
 }
 
@@ -110,7 +112,7 @@ export interface PageConfig {
   path: string
   title: string
   level: AppLevel
-  componentTree: any[]
+  componentTree: unknown[]
   requiresAuth: boolean
   requiredRole?: UserRole
 }
@@ -122,14 +124,14 @@ export interface Tenant {
   createdAt: number
   homepageConfig?: {
     pageId: string
-    customContent?: any
+    customContent?: unknown
   }
 }
 
 export interface AppConfiguration {
   id: string
   name: string
-  schemas: any[]
+  schemas: ModelSchema[]
   workflows: Workflow[]
   luaScripts: LuaScript[]
   pages: PageConfig[]

--- a/frontends/nextjs/src/lib/types/schema-types.ts
+++ b/frontends/nextjs/src/lib/types/schema-types.ts
@@ -48,7 +48,7 @@ export interface FieldSchema {
   label?: string
   required?: boolean
   unique?: boolean
-  default?: any
+  default?: unknown
   choices?: Array<{ value: string; label: string }>
   relatedModel?: string
   helpText?: string | string[]

--- a/frontends/nextjs/src/types/monaco-editor-react.d.ts
+++ b/frontends/nextjs/src/types/monaco-editor-react.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module '@monaco-editor/react' {
   import type { ComponentType } from 'react'
   


### PR DESCRIPTION
## Summary
- replace package data `any` types with shared `PackageSeedData`/`PackageSeedRecord` aliases across API and database helpers
- tighten shared builder, schema, and level types to avoid explicit `any` usage
- silence unavoidable `any` usage in monaco type declarations and verify lint on updated files

## Testing
- npx eslint src/lib/api/packages/data src/lib/db/packages/data/get/get-package-data.ts src/lib/db/packages/data/set-package-data.ts src/lib/types src/lib/packages/core/package-types.ts src/types/monaco-editor-react.d.ts --max-warnings=0


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530f6d0c20833193a6e27c5ce0dd9f)