### PR TITLE
Add GitLab CI workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,37 @@
+image: node:20-bullseye
+
+stages:
+  - lint
+  - test
+  - build
+
+cache:
+  key: ${CI_COMMIT_REF_SLUG}
+  paths:
+    - .npm/
+
+variables:
+  NPM_CONFIG_CACHE: $CI_PROJECT_DIR/.npm
+
+before_script:
+  - npm ci
+
+lint:
+  stage: lint
+  script:
+    - npm run lint
+
+typecheck:
+  stage: test
+  script:
+    - npm run typecheck
+
+unit_tests:
+  stage: test
+  script:
+    - npm test
+
+build:
+  stage: build
+  script:
+    - npm run build


### PR DESCRIPTION
### Motivation
- Add a GitLab CI pipeline to run lint, typecheck, unit tests, and build on GitLab with npm caching to speed up installs.

### Description
- Add `.gitlab-ci.yml` using `node:20-bullseye` that defines `lint`, `test`, and `build` stages, configures `NPM_CONFIG_CACHE` to `$CI_PROJECT_DIR/.npm`, runs `npm ci` in `before_script`, and adds jobs `lint`, `typecheck`, `unit_tests`, and `build` with a cache keyed by `${CI_COMMIT_REF_SLUG}` storing `.npm/`.

### Testing
- No automated tests were run for this change; the CI configuration will execute `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` when the pipeline runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966f2b2a534833193fc86af3c614b37)