### PR TITLE
Fix DBAL OIDC login: register production redirect URIs

### DIFF
--- a/libraries/dbal/shared/api/schema/oidc/clients.json
+++ b/libraries/dbal/shared/api/schema/oidc/clients.json
@@ -9,11 +9,13 @@
       "response_types": ["code"],
       "redirect_uris": [
         "http://localhost:3000/pastebin/auth/callback",
-        "http://rdesktop.local:8900/pastebin/auth/callback"
+        "http://rdesktop.local:8900/pastebin/auth/callback",
+        "https://metabuilder.wardcrew.com/pastebin/auth/callback"
       ],
       "post_logout_redirect_uris": [
         "http://localhost:3000/pastebin/",
-        "http://rdesktop.local:8900/pastebin/"
+        "http://rdesktop.local:8900/pastebin/",
+        "https://metabuilder.wardcrew.com/pastebin/"
       ],
       "require_pkce": true,
       "pkce_methods": ["S256"],
@@ -30,11 +32,13 @@
       "response_types": ["code"],
       "redirect_uris": [
         "http://localhost:3000/dbal/auth/callback",
-        "http://rdesktop.local:8900/dbal/auth/callback"
+        "http://rdesktop.local:8900/dbal/auth/callback",
+        "https://metabuilder.wardcrew.com/dbal/auth/callback"
       ],
       "post_logout_redirect_uris": [
         "http://localhost:3000/dbal/",
-        "http://rdesktop.local:8900/dbal/"
+        "http://rdesktop.local:8900/dbal/",
+        "https://metabuilder.wardcrew.com/dbal/"
       ],
       "require_pkce": true,
       "pkce_methods": ["S256"],
@@ -51,11 +55,13 @@
       "response_types": ["code"],
       "redirect_uris": [
         "http://localhost:3000/codegen/auth/callback",
-        "http://rdesktop.local:8900/codegen/auth/callback"
+        "http://rdesktop.local:8900/codegen/auth/callback",
+        "https://metabuilder.wardcrew.com/codegen/auth/callback"
       ],
       "post_logout_redirect_uris": [
         "http://localhost:3000/codegen/",
-        "http://rdesktop.local:8900/codegen/"
+        "http://rdesktop.local:8900/codegen/",
+        "https://metabuilder.wardcrew.com/codegen/"
       ],
       "require_pkce": true,
       "pkce_methods": ["S256"],
@@ -72,11 +78,13 @@
       "response_types": ["code"],
       "redirect_uris": [
         "http://localhost:3000/app/auth/callback",
-        "http://rdesktop.local:8900/app/auth/callback"
+        "http://rdesktop.local:8900/app/auth/callback",
+        "https://metabuilder.wardcrew.com/app/auth/callback"
       ],
       "post_logout_redirect_uris": [
         "http://localhost:3000/app/",
-        "http://rdesktop.local:8900/app/"
+        "http://rdesktop.local:8900/app/",
+        "https://metabuilder.wardcrew.com/app/"
       ],
       "require_pkce": true,
       "pkce_methods": ["S256"],
@@ -93,11 +101,13 @@
       "response_types": ["code"],
       "redirect_uris": [
         "http://localhost:3000/terminal/auth/callback",
-        "http://rdesktop.local:8900/terminal/auth/callback"
+        "http://rdesktop.local:8900/terminal/auth/callback",
+        "https://metabuilder.wardcrew.com/terminal/auth/callback"
       ],
       "post_logout_redirect_uris": [
         "http://localhost:3000/terminal/",
-        "http://rdesktop.local:8900/terminal/"
+        "http://rdesktop.local:8900/terminal/",
+        "https://metabuilder.wardcrew.com/terminal/"
       ],
       "require_pkce": true,
       "pkce_methods": ["S256"],
@@ -114,11 +124,13 @@
       "response_types": ["code"],
       "redirect_uris": [
         "http://localhost:3000/packagerepo/auth/callback",
-        "http://rdesktop.local:8900/packagerepo/auth/callback"
+        "http://rdesktop.local:8900/packagerepo/auth/callback",
+        "https://metabuilder.wardcrew.com/packagerepo/auth/callback"
       ],
       "post_logout_redirect_uris": [
         "http://localhost:3000/packagerepo/",
-        "http://rdesktop.local:8900/packagerepo/"
+        "http://rdesktop.local:8900/packagerepo/",
+        "https://metabuilder.wardcrew.com/packagerepo/"
       ],
       "require_pkce": true,
       "pkce_methods": ["S256"],
@@ -135,11 +147,13 @@
       "response_types": ["code"],
       "redirect_uris": [
         "http://localhost:3000/postgres/admin/auth/callback",
-        "http://rdesktop.local:8900/postgres/admin/auth/callback"
+        "http://rdesktop.local:8900/postgres/admin/auth/callback",
+        "https://metabuilder.wardcrew.com/postgres/admin/auth/callback"
       ],
       "post_logout_redirect_uris": [
         "http://localhost:3000/postgres/",
-        "http://rdesktop.local:8900/postgres/"
+        "http://rdesktop.local:8900/postgres/",
+        "https://metabuilder.wardcrew.com/postgres/"
       ],
       "require_pkce": true,
       "pkce_methods": ["S256"],
@@ -156,11 +170,13 @@
       "response_types": ["code"],
       "redirect_uris": [
         "http://localhost:3000/workflowui/auth/callback",
-        "http://rdesktop.local:8900/workflowui/auth/callback"
+        "http://rdesktop.local:8900/workflowui/auth/callback",
+        "https://metabuilder.wardcrew.com/workflowui/auth/callback"
       ],
       "post_logout_redirect_uris": [
         "http://localhost:3000/workflowui/",
-        "http://rdesktop.local:8900/workflowui/"
+        "http://rdesktop.local:8900/workflowui/",
+        "https://metabuilder.wardcrew.com/workflowui/"
       ],
       "require_pkce": true,
       "pkce_methods": ["S256"],
@@ -177,11 +193,13 @@
       "response_types": ["code"],
       "redirect_uris": [
         "http://localhost:3000/emailclient/auth/callback",
-        "http://rdesktop.local:8900/emailclient/auth/callback"
+        "http://rdesktop.local:8900/emailclient/auth/callback",
+        "https://metabuilder.wardcrew.com/emailclient/auth/callback"
       ],
       "post_logout_redirect_uris": [
         "http://localhost:3000/emailclient/",
-        "http://rdesktop.local:8900/emailclient/"
+        "http://rdesktop.local:8900/emailclient/",
+        "https://metabuilder.wardcrew.com/emailclient/"
       ],
       "require_pkce": true,
       "pkce_methods": ["S256"],


### PR DESCRIPTION
## Summary

- Investigated a report that signing in on `https://metabuilder.wardcrew.com/app` (e.g. as the seeded `god` account) landed on a blank white page with raw JSON text instead of the DBAL login form.
- Root cause: `libraries/dbal/shared/api/schema/oidc/clients.json` — DBAL's declarative OIDC client registry — only lists `http://localhost:3000/...` and `http://rdesktop.local:8900/...` `redirect_uris` for every client. On the live deployment, the frontend computes `redirect_uri` from `window.location.origin` (`https://metabuilder.wardcrew.com`), so `GET /api/dbal/oidc/authorize` rejects it with `{"error":"invalid_request","error_description":"redirect_uri not registered for this client"}` before ever reaching DBAL's `/oidc/login` page — the browser just renders that raw JSON body unstyled.
- Fix: add `https://metabuilder.wardcrew.com/<app>/auth/callback` (and matching `post_logout_redirect_uris` entry) to all 8 client entries, matching the single-domain path-based routing in `deployment/config/nginx/production.conf` (`/app`, `/pastebin`, `/codegen`, `/dbal`, `/terminal`, `/packagerepo`, `/postgres/admin`, `/workflowui`, `/emailclient`).

## Test plan

- [x] `python3 -m json.tool` validates the edited file
- [x] Confirmed via `curl` against the live DBAL OIDC endpoints that `GET /api/dbal/oidc/authorize` with the production `redirect_uri` currently 400s with the JSON body described above (reproducing the bug)
- [x] Confirmed via `curl` that the registered `localhost:3000` redirect_uri correctly 302s to DBAL's `/oidc/login`, which renders a properly styled login form (so DBAL's login page itself is fine — only the redirect_uri allowlist was wrong)
- [ ] Deploy `dbal`/`dbal-init` with this change and re-verify `Sign In` on `https://metabuilder.wardcrew.com/app` reaches the DBAL login page and completes login as `god` / `god-Demo1!`
- [x] `libraries/dbal/production/tests/security/oauth_client_config_post_logout_test.cpp` uses its own inline fixture JSON, unaffected by this change

Note: `DBAL_OIDC_CLIENTS_CONFIG` is loaded once at DBAL startup (default `/app/schemas/oidc/clients.json`, baked into the `dbal`/`dbal-init` images), so this requires a rebuild + redeploy of those images to take effect in production.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1gJUidTXM6EMnBYuMsQL6)_